### PR TITLE
Update _legacy.pyx to fix return type of load()

### DIFF
--- a/src/_legacy.pyx
+++ b/src/_legacy.pyx
@@ -47,7 +47,7 @@ def load(fp, **kw):
 
     Returns
     -------
-    str
+    object
         see :func:`decode_io(…) <pyjson5.decode_io>`
     '''
     return decode_io(fp, None, False)


### PR DESCRIPTION
load() returns an object not a str.
Changed return type in documentation of load() from str to object. Useful for IDE type checks.