### PR TITLE
Fix Termux installation error

### DIFF
--- a/src/_imports.pyx
+++ b/src/_imports.pyx
@@ -9,7 +9,6 @@ from cpython.bytes cimport (
 )
 from cpython.dict cimport PyDict_SetItem
 from cpython.float cimport PyFloat_Check, PyFloat_AsDouble, PyFloat_FromDouble
-from cpython.int cimport PyInt_Check
 from cpython.list cimport PyList_Append
 from cpython.long cimport PyLong_FromString, PyLong_Check
 from cpython.object cimport PyObject, PyObject_GetIter


### PR DESCRIPTION
This change fixes installation error on Termux (see attached [log.txt](https://github.com/user-attachments/files/20159787/log.txt)) or when building locally.

I would really appreciate if this change can be deployed as soon as possible, pyjson5 is used in my own python package where Termux users make up a substantial part of the userbase. Thanks!