### PR TITLE
Add cythonize annotations to improve DX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-from setuptools import setup, Extension
+from Cython.Build import cythonize
+from setuptools import Extension, setup
 
 extra_compile_args = [
     "-std=c++11",
@@ -11,15 +12,21 @@ extra_compile_args = [
     "-fomit-frame-pointer",
 ]
 
+extensions = [
+    Extension(
+        "pyjson5.pyjson5",
+        sources=["pyjson5.pyx"],
+        include_dirs=["src"],
+        extra_compile_args=extra_compile_args,
+        extra_link_args=extra_compile_args,
+        language="c++",
+    ),
+]
+
 setup(
-    ext_modules=[
-        Extension(
-            "pyjson5.pyjson5",
-            sources=["pyjson5.pyx"],
-            include_dirs=["src"],
-            extra_compile_args=extra_compile_args,
-            extra_link_args=extra_compile_args,
-            language="c++",
-        )
-    ],
+    ext_modules=cythonize(
+        extensions,
+        compiler_directives={"language_level": 3},
+        annotate=True,
+    ),
 )


### PR DESCRIPTION
This doesn't change the build output, and allows developers to read
HTML "annotations" (reports, generated by cythonize) which show how
cython code is being compiled.

---

This was suggested to me by a friend who helped me with #108.

If it's contentious, I could maybe make this controllable, e.g. with an env var?