### PR TITLE
Build CPython 3.14 wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         python:
           - '3.10'
           - '3.13'
+          - '3.14'
 
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +32,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
 
       - name: Display Python version
         run: python -c 'import sys; print(sys.version)'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.13'
   
       - run: python -m pip install -U pip wheel setuptools
-      - run: python -m pip install -U 'cibuildwheel==2.*'
+      - run: python -m pip install -U 'cibuildwheel==3.*'
 
       - id: set-matrix
         run: |
@@ -47,7 +47,7 @@ jobs:
           python-version: '3.13'
   
       - run: python -m pip install -U pip wheel setuptools
-      - run: python -m pip install -U 'cibuildwheel==2.*'
+      - run: python -m pip install -U 'cibuildwheel==3.*'
 
       - id: set-matrix
         run: |
@@ -75,7 +75,7 @@ jobs:
           python-version: '3.13'
   
       - run: python -m pip install -U pip wheel setuptools
-      - run: python -m pip install -U 'cibuildwheel==2.*'
+      - run: python -m pip install -U 'cibuildwheel==3.*'
 
       - id: set-matrix
         run: |
@@ -120,7 +120,7 @@ jobs:
   
       - run: python -m pip install -U pip wheel setuptools
       - run: python -m pip install -Ur requirements-dev.txt
-      - run: python -m pip install -U 'cibuildwheel==2.*'
+      - run: python -m pip install -U 'cibuildwheel==3.*'
 
       - run: make prepare
 
@@ -165,7 +165,7 @@ jobs:
   
       - run: python -m pip install -U pip wheel setuptools
       - run: python -m pip install -Ur requirements-dev.txt
-      - run: python -m pip install -U 'cibuildwheel==2.*'
+      - run: python -m pip install -U 'cibuildwheel==3.*'
 
       - run: make prepare
 
@@ -210,7 +210,7 @@ jobs:
   
       - run: python -m pip install -U pip wheel setuptools
       - run: python -m pip install -Ur requirements-dev.txt
-      - run: python -m pip install -U 'cibuildwheel==2.*'
+      - run: python -m pip install -U 'cibuildwheel==3.*'
 
       - run: make prepare
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**Unreleased**
+
+* Update for Python 3.14 and require at least 3.8 (by Edgar Ramírez, [#112](https://github.com/Kijewski/pyjson5/pull/112))
+
 **1.6.9 (2025-05-12)**
 
 * Remove unused import to fix installation on Termux (by veka0, [#105](https://github.com/Kijewski/pyjson5/pull/105))

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,13 +35,13 @@ classifiers =
     Programming Language :: Cython
     Programming Language :: JavaScript
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Text Processing :: General
@@ -49,7 +49,7 @@ classifiers =
 [options]
 zip_safe = False
 
-python_requires = ~= 3.7
+python_requires = ~= 3.8
 setup_requires =
     Cython
     setuptools


### PR DESCRIPTION
The bump of cibuildwheel to v3 also means 3.7 wheels are no longer built.