### PR TITLE
Build CPython 3.15 wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,23 +16,24 @@ jobs:
           - '3.10'
           - '3.13'
           - '3.14'
-          - '3.13t'
+          - '3.15'
           - '3.14t'
+          - '3.15t'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - name: Cache pip
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           key: cache--${{ matrix.os }}--${{ matrix.python }}--${{ hashFiles('./requirements*.txt', './Makefile') }}
           restore-keys: cache--${{ matrix.os }}--${{ matrix.python }}--
           path: ~/.cache/pip
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
@@ -81,19 +82,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - name: Cache pip
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           key: lint--${{ hashFiles('./requirements*.txt', './Makefile') }}
           restore-keys: lint--
           path: ~/.cache/pip
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: true
 
@@ -35,7 +35,7 @@ jobs:
         path: ~/.cache/pip
 
     - name: Setup python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ github.event.inputs.python }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,17 +9,17 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 
       - run: python -m pip install -U pip wheel setuptools
-      - run: python -m pip install -U 'cibuildwheel==3.*'
+      - run: python -m pip install -U 'cibuildwheel==4.*
 
       - id: set-matrix
         run: |
@@ -38,17 +38,17 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 
       - run: python -m pip install -U pip wheel setuptools
-      - run: python -m pip install -U 'cibuildwheel==3.*'
+      - run: python -m pip install -U 'cibuildwheel==4.*
 
       - id: set-matrix
         run: |
@@ -67,17 +67,17 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 
       - run: python -m pip install -U pip wheel setuptools
-      - run: python -m pip install -U 'cibuildwheel==3.*'
+      - run: python -m pip install -U 'cibuildwheel==4.*
 
       - id: set-matrix
         run: |
@@ -96,17 +96,17 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 
       - run: python -m pip install -U pip wheel setuptools
-      - run: python -m pip install -U 'cibuildwheel==3.*'
+      - run: python -m pip install -U 'cibuildwheel==4.*
 
       - id: set-matrix
         run: |
@@ -130,7 +130,7 @@ jobs:
         only: ${{ fromJSON(needs.linux-define-matrix.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
@@ -140,19 +140,19 @@ jobs:
           platforms: all
 
       - name: Cache pip
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           key: linux--${{ hashFiles('./requirements-dev.txt') }}
           path: ~/.cache/pip
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 
       - run: python -m pip install -U pip wheel setuptools
       - run: python -m pip install -Ur requirements-dev.txt
-      - run: python -m pip install -U 'cibuildwheel==3.*'
+      - run: python -m pip install -U 'cibuildwheel==4.*
 
       - run: make prepare
 
@@ -183,24 +183,24 @@ jobs:
         only: ${{ fromJSON(needs.pyodide-define-matrix.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - name: Cache pip
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           key: pyodide--${{ hashFiles('./requirements-dev.txt') }}
           path: ~/.cache/pip
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 
       - run: python -m pip install -U pip wheel setuptools
       - run: python -m pip install -Ur requirements-dev.txt
-      - run: python -m pip install -U 'cibuildwheel==3.*'
+      - run: python -m pip install -U 'cibuildwheel==4.*
 
       - run: make prepare
 
@@ -229,24 +229,24 @@ jobs:
         only: ${{ fromJSON(needs.macos-define-matrix.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - name: Cache pip
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           key: windows--${{ hashFiles('./requirements-dev.txt') }}
           path: ~/.cache/pip
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 
       - run: python -m pip install -U pip wheel setuptools
       - run: python -m pip install -Ur requirements-dev.txt
-      - run: python -m pip install -U 'cibuildwheel==3.*'
+      - run: python -m pip install -U 'cibuildwheel==4.*
 
       - run: make prepare
 
@@ -277,24 +277,24 @@ jobs:
         only: ${{ fromJSON(needs.windows-define-matrix.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - name: Cache pip
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           key: windows--${{ hashFiles('./requirements-dev.txt') }}
           path: ~/.cache/pip
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 
       - run: python -m pip install -U pip wheel setuptools
       - run: python -m pip install -Ur requirements-dev.txt
-      - run: python -m pip install -U 'cibuildwheel==3.*'
+      - run: python -m pip install -U 'cibuildwheel==4.*
 
       - run: make prepare
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**Unreleased**
+
+* Update for Python 3.15, require at least 3.9 and drop 3.13t wheels (by Edgar Ramírez, [#157](https://github.com/Kijewski/pyjson5/pull/157))
+
 **2.0.1 (2026-05-15)**
 
 * Support Python free-threaded builds (PEP 703). The extension now opts into

--- a/README.rst
+++ b/README.rst
@@ -56,4 +56,4 @@ use the functions ``encode_*()`` and ``decode_*()`` instead.
 Compatibility
 -------------
 
-At least CPython 3.8 or a recent Pypy3 version is needed.
+At least CPython 3.9 or a recent Pypy3 version is needed.

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ classifiers =
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3.14
+    Programming Language :: Python :: 3.15
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Free Threading :: 2 - Beta
     Programming Language :: Python :: Implementation :: CPython
@@ -48,7 +49,7 @@ classifiers =
 [options]
 zip_safe = False
 
-python_requires = ~= 3.8
+python_requires = ~= 3.9
 setup_requires =
     Cython
     setuptools


### PR DESCRIPTION
I also briefly explored building abi3 and abi3t wheels, but that seems to require changes to the Cython code and may not even be doable without sacrificing performance.

Jobs: https://github.com/edgarrmondragon/pyjson5/actions/runs/31133197780/